### PR TITLE
[map][android] Add toggle for minimum visible fog trail size

### DIFF
--- a/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
+++ b/android/app/src/main/java/app/organicmaps/settings/SettingsPrefsFragment.java
@@ -13,6 +13,7 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.SeekBarPreference;
+import androidx.preference.SwitchPreferenceCompat;
 import androidx.preference.TwoStatePreference;
 import app.organicmaps.MwmApplication;
 import app.organicmaps.R;
@@ -583,6 +584,16 @@ public class SettingsPrefsFragment extends BaseXmlSettingsFragment implements La
       gradientPref.setOnPreferenceChangeListener((preference, newValue) -> {
         Framework.nativeSetFogOfWarGradient((Integer) newValue);
         gradientPref.setSummary(newValue + "%");
+        return true;
+      });
+    }
+
+    final SwitchPreferenceCompat minVisiblePref = findPreference(getString(R.string.pref_fog_of_war_min_visible));
+    if (minVisiblePref != null)
+    {
+      minVisiblePref.setChecked(Framework.nativeIsFogOfWarMinVisible());
+      minVisiblePref.setOnPreferenceChangeListener((preference, newValue) -> {
+        Framework.nativeSetFogOfWarMinVisible((Boolean) newValue);
         return true;
       });
     }

--- a/android/app/src/main/res/values/donottranslate.xml
+++ b/android/app/src/main/res/values/donottranslate.xml
@@ -60,6 +60,7 @@
   <string name="pref_fog_of_war_color" translatable="false">FogOfWarColor</string>
   <string name="pref_fog_of_war_advanced" translatable="false">FogOfWarAdvanced</string>
   <string name="pref_fog_of_war_gradient" translatable="false">FogOfWarGradient</string>
+  <string name="pref_fog_of_war_min_visible" translatable="false">FogOfWarMinVisible</string>
   <string name="pref_fog_throttle_speed1" translatable="false">FogThrottleSpeed1</string>
   <string name="pref_fog_throttle_speed2" translatable="false">FogThrottleSpeed2</string>
   <string name="pref_fog_throttle_speed3" translatable="false">FogThrottleSpeed3</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -654,6 +654,8 @@
     <string name="pref_fog_of_war_advanced_title">Advanced settings</string>
     <string name="pref_fog_of_war_gradient_title">Gradient width</string>
     <string name="pref_fog_of_war_gradient_summary">Transition zone between clear and fogged area (%)</string>
+    <string name="pref_fog_of_war_min_visible_title">Minimum visible size</string>
+    <string name="pref_fog_of_war_min_visible_summary">Keep revealed trail visible when zoomed out, even if it exceeds its real-world area</string>
     <string name="prefs_fog_throttle_slow">Slow movement (e.g. walking)</string>
     <string name="prefs_fog_throttle_medium">Medium movement (e.g. cycling)</string>
     <string name="prefs_fog_throttle_fast">Fast movement (e.g. driving)</string>

--- a/android/app/src/main/res/xml/prefs_main.xml
+++ b/android/app/src/main/res/xml/prefs_main.xml
@@ -211,9 +211,16 @@
         app:showSeekBarValue="true"
         app:updatesContinuously="true"
         android:order="1" />
+      <androidx.preference.SwitchPreferenceCompat
+        android:key="@string/pref_fog_of_war_min_visible"
+        android:title="@string/pref_fog_of_war_min_visible_title"
+        app:singleLineTitle="false"
+        android:summary="@string/pref_fog_of_war_min_visible_summary"
+        android:defaultValue="true"
+        android:order="2" />
       <androidx.preference.PreferenceCategory
         android:title="@string/prefs_fog_throttle_slow"
-        android:order="2">
+        android:order="3">
         <androidx.preference.SeekBarPreference
           android:key="@string/pref_fog_throttle_speed1"
           android:title="@string/pref_fog_throttle_speed1_title"
@@ -239,7 +246,7 @@
       </androidx.preference.PreferenceCategory>
       <androidx.preference.PreferenceCategory
         android:title="@string/prefs_fog_throttle_medium"
-        android:order="3">
+        android:order="4">
         <androidx.preference.SeekBarPreference
           android:key="@string/pref_fog_throttle_speed2"
           android:title="@string/pref_fog_throttle_speed2_title"
@@ -265,7 +272,7 @@
       </androidx.preference.PreferenceCategory>
       <androidx.preference.PreferenceCategory
         android:title="@string/prefs_fog_throttle_fast"
-        android:order="4">
+        android:order="5">
         <androidx.preference.SeekBarPreference
           android:key="@string/pref_fog_throttle_speed3"
           android:title="@string/pref_fog_throttle_speed3_title"
@@ -291,7 +298,7 @@
       </androidx.preference.PreferenceCategory>
       <androidx.preference.PreferenceCategory
         android:title="@string/prefs_fog_throttle_very_fast"
-        android:order="5">
+        android:order="6">
         <androidx.preference.SeekBarPreference
           android:key="@string/pref_fog_throttle_interval4"
           android:title="@string/pref_fog_throttle_interval4_title"

--- a/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
+++ b/android/sdk/src/main/cpp/app/organicmaps/sdk/Framework.cpp
@@ -1604,6 +1604,16 @@ JNIEXPORT jint Java_app_organicmaps_sdk_Framework_nativeGetFogOfWarGradient(JNIE
   return static_cast<jint>(Framework::GetFogOfWarGradient());
 }
 
+JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeSetFogOfWarMinVisible(JNIEnv *, jclass, jboolean enabled)
+{
+  frm()->SetFogOfWarMinVisible(static_cast<bool>(enabled));
+}
+
+JNIEXPORT jboolean Java_app_organicmaps_sdk_Framework_nativeIsFogOfWarMinVisible(JNIEnv *, jclass)
+{
+  return static_cast<jboolean>(Framework::GetFogOfWarMinVisible());
+}
+
 JNIEXPORT void Java_app_organicmaps_sdk_Framework_nativeSetFogThrottleSpeed(JNIEnv *, jclass, jint tier, jint speed)
 {
   Framework::SetFogThrottleSpeed(static_cast<int>(tier), static_cast<int>(speed));

--- a/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
+++ b/android/sdk/src/main/java/app/organicmaps/sdk/Framework.java
@@ -307,6 +307,8 @@ public class Framework
   public static native int nativeGetFogOfWarColor();
   public static native void nativeSetFogOfWarGradient(int percent);
   public static native int nativeGetFogOfWarGradient();
+  public static native void nativeSetFogOfWarMinVisible(boolean enabled);
+  public static native boolean nativeIsFogOfWarMinVisible();
   public static native void nativeSetFogThrottleSpeed(int tier, int speed);
   public static native int nativeGetFogThrottleSpeed(int tier);
   public static native void nativeSetFogThrottleInterval(int tier, int interval);

--- a/libs/map/framework.cpp
+++ b/libs/map/framework.cpp
@@ -110,6 +110,7 @@ std::string_view constexpr kFogOfWarRadiusKey = "FogOfWarRadius";
 std::string_view constexpr kFogOfWarOpacityKey = "FogOfWarOpacity";
 std::string_view constexpr kFogOfWarColorKey = "FogOfWarColor";
 std::string_view constexpr kFogOfWarGradientKey = "FogOfWarGradient";
+std::string_view constexpr kFogOfWarMinVisibleKey = "FogOfWarMinVisible";
 std::string_view constexpr kFogThrottleSpeed1Key = "FogThrottleSpeed1";
 std::string_view constexpr kFogThrottleSpeed2Key = "FogThrottleSpeed2";
 std::string_view constexpr kFogThrottleSpeed3Key = "FogThrottleSpeed3";
@@ -1596,11 +1597,13 @@ void Framework::CreateDrapeEngine(ref_ptr<dp::GraphicsContextFactory> contextFac
       double const tileWidth = tileRect.SizeX();
       double const tileHeight = tileRect.SizeY();
 
-      // Ensure reveals are always visible: enforce a minimum pixel radius
-      // so the trail doesn't vanish at high zoom-out levels.
+      // When "minimum visible size" is enabled, enforce a floor so the trail
+      // doesn't vanish at high zoom-out levels.  Otherwise use true scale.
       constexpr double kMinRadiusPx = 8.0;
-      double const radiusPx = std::max(kMinRadiusPx,
-                                        revealRadiusMercator / tileWidth * kTileSize);
+      double const naturalRadiusPx = revealRadiusMercator / tileWidth * kTileSize;
+      bool const minVisible = GetFogOfWarMinVisible();
+      double const radiusPx = minVisible ? std::max(kMinRadiusPx, naturalRadiusPx)
+                                         : naturalRadiusPx;
 
       auto expandedRect = tileRect;
       expandedRect.Inflate(revealRadiusMercator, revealRadiusMercator);
@@ -3228,6 +3231,19 @@ int Framework::GetFogOfWarGradient()
 void Framework::SetFogOfWarGradient(int percent)
 {
   settings::Set(kFogOfWarGradientKey, percent);
+  InvalidateFogTiles();
+}
+
+bool Framework::GetFogOfWarMinVisible()
+{
+  bool enabled = true;
+  settings::Get(kFogOfWarMinVisibleKey, enabled);
+  return enabled;
+}
+
+void Framework::SetFogOfWarMinVisible(bool enabled)
+{
+  settings::Set(kFogOfWarMinVisibleKey, enabled);
   InvalidateFogTiles();
 }
 

--- a/libs/map/framework.hpp
+++ b/libs/map/framework.hpp
@@ -756,6 +756,8 @@ public:
   void SetFogOfWarColor(int colorIndex);
   static int GetFogOfWarGradient();
   void SetFogOfWarGradient(int percent);
+  static bool GetFogOfWarMinVisible();
+  void SetFogOfWarMinVisible(bool enabled);
   static int GetFogThrottleSpeed(int tier);
   static void SetFogThrottleSpeed(int tier, int speed);
   static int GetFogThrottleInterval(int tier);


### PR DESCRIPTION
Add a 'Minimum visible size' switch to the fog-of-war advanced settings. When enabled (default), the revealed trail is kept at least 8 pixels wide even at low zoom levels, which inflates its physical area beyond what was actually visited.  When disabled, the trail is rendered at true physical scale and may become invisible at world-overview zoom levels.

The setting is wired through all layers:
- C++: GetFogOfWarMinVisible / SetFogOfWarMinVisible with persistent storage key 'FogOfWarMinVisible' (defaults to true).
- JNI: nativeIsFogOfWarMinVisible / nativeSetFogOfWarMinVisible.
- Android UI: SwitchPreferenceCompat in the advanced settings sub-screen.